### PR TITLE
[Install] Add install rule to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OBJ			=	$(SRC:.cpp=.o)
 NAME		=	IO_Tester
 
 ifdef DEBUG
-	CXXFLAGS += -ggdb3
+	CXXFLAGS	+=	-ggdb3
 endif
 
 all:	$(NAME)
@@ -25,6 +25,14 @@ all:	$(NAME)
 $(NAME):	$(OBJ)
 	$(CXX) -o $(NAME) $(OBJ)
 	$(RM) $(OBJ)
+
+install: all
+	@echo -e "\033[92mCopying IO_Tester into /usr/bin\033[0m"
+	@sudo cp $(NAME) /usr/bin
+
+user_install: all
+	@echo -e "\033[92mCopying IO_Tester into ${HOME}/.local/bin\033[0m"
+	@cp $(NAME) ${HOME}/.local/bin
 
 clean:
 	$(RM) $(OBJ)


### PR DESCRIPTION
This install rule is in place in order to copy the binary into /usr/bin
to allow to use the program from any project without the hassle to copy
the binary into the repository.
The user_install rule is quite similar but instead of copying the binary
into /usr/bin, it copies it into ${HOME}/.local/bin for those who want
to install it for a single user instead of installing it system wide.
This requires you to have this path in your PATH environment variable.